### PR TITLE
Fixed as GpuSort works fine about a table with some positive data type that is not used often.

### DIFF
--- a/src/gpusort.c
+++ b/src/gpusort.c
@@ -385,7 +385,7 @@ gpusort_projection_addcase(StringInfo body,
 						   bool type_byval,
 						   bool is_sortkey)
 {
-	if (type_len > 0)
+	if (type_len > 0 && is_sortkey)
 	{
 		const char *type_cast;
 


### PR DESCRIPTION
I found a bug that GpuSort doesn't work about a table with following data type.

```
contrib_regression=# select typname,typlen from pg_type where typlen>0 and typlen not in (1,2,4,8);
  typname  | typlen 
-----------+--------
 name      |     64
 tid       |      6
 point     |     16
 lseg      |     32
 box       |     32
 line      |     24
 tinterval |     12
 circle    |     24
 macaddr   |      6
 aclitem   |     12
 interval  |     16
 timetz    |     12
 uuid      |     16
(13 rows)
```

GpuSort occurs this error.
```
ERROR:  unexpected length of data type
```
Please merge this.