### PR TITLE
Fix build error caused by incomplete parenthesis.

### DIFF
--- a/src/cuda_timelib.h
+++ b/src/cuda_timelib.h
@@ -1196,7 +1196,7 @@ assign_timelib_session_info(StringInfo buf)
 
 	appendStringInfo(
 		buf,
-		"#endif /* __CUDACC__ */\n"
+		"#endif /* __CUDACC__ */\n");
 }
 
 #endif	/* __CUDACC__ */


### PR DESCRIPTION
I found incomplete parenthesis caused build error in cuda_timelib.h.
I made a patch for this issue, and I believe it might work.
